### PR TITLE
Fixed urls in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ South==0.8.4
 argparse==1.1
 beautifulsoup4==4.3.2
 django-bootstrap3-datetimepicker==2.2.3
--e git+https://github.com/PyAr/django-disqus.git@adcb83c617be475b2918067ba5318366098e33bf#egg=django_disqus-origin/HEAD
+-e git+https://github.com/PyAr/django-disqus.git@adcb83c617be475b2918067ba5318366098e33bf#egg=django_disqus
 django-extensions==1.3.3
 django-pagination-py3==1.1.1
 django-planet==0.6.2
@@ -12,7 +12,7 @@ django-registration==1.0
 django-summernote==0.5.6
 django-tagging==0.3.2
 django-taggit==0.11.2
--e git+https://github.com/PyAr/django-taggit-autosuggest.git@48460dc0703800c16a8b7a780b8f2235e09f3b91#egg=django_taggit_autosuggest-origin/HEAD
+-e git+https://github.com/PyAr/django-taggit-autosuggest.git@48460dc0703800c16a8b7a780b8f2235e09f3b91#egg=django_taggit_autosuggest
 feedparser==5.1.3
 ipdb==0.8
 ipython==1.2.0


### PR DESCRIPTION
removed the "-origin/HEAD" from git urls in requirements, to make them pip compliant. Fix #93
