### PR TITLE
fixing requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ ipdb==0.8
 ipython==1.2.0
 requests==2.2.1
 six==1.6.1
-tagging==0.2.1
+#tagging==0.2.1


### PR DESCRIPTION
no se si se rompe algo sacando tagging==0.2.1 de requirements pero igual no se podía correr ni runserver, ni syncdb, lo saque y lo desinstale y ahora corre por lo menos, el que lo ocupó la librería en alguna feature, que se fije por favor.

Otra cosa Instalar django-disqus a mano no hace falta, yo instale solamente del requirements y funca, acá la prueba 
![django-discus](https://cloud.githubusercontent.com/assets/1647454/2728249/d2c9e5e0-c5ec-11e3-8a59-cb2dff455226.png)
