### PR TITLE
Fix Search, dont allow to Search for Empty String, use HTML5 input type ...

### DIFF
--- a/community/templates/base_site.html
+++ b/community/templates/base_site.html
@@ -26,7 +26,7 @@
 
 
           <form id="search-form" class="input-group" role="form" action="{% url "buscador" %}" method="get">
-              <input type="text" name="buscar" class="form-control input-lg" placeholder="Buscar...">
+              <input type="search" name="buscar" class="form-control input-lg" placeholder="Buscar..." required >
               <span class="input-group-btn">
                   <button class="btn btn-default btn-lg" type="submit">
                       <span class="glyphicon glyphicon-search"></span>


### PR DESCRIPTION
- Fix Search
- Dont allow to Search for Empty String.
- Use HTML5 input type Search.
- UI is not changed.

:pear: 
