### PR TITLE
Implementacion de pagina de usuario en la wiki (#265)

### DIFF
--- a/community/models.py
+++ b/community/models.py
@@ -1,3 +1,23 @@
-from django.db import models
+from allauth.account.signals import user_signed_up
+from waliki.models import ACLRule
+from django.contrib.auth.models import Permission
+from waliki.settings import get_slug
+from django.dispatch import receiver
 
-# Create your models here.
+
+@receiver(user_signed_up)
+def create_acl_for_user_wiki_own_page(sender, **kwargs):
+    user = kwargs['user']
+    perms = Permission.objects.filter(content_type__app_label='waliki',
+                                      codename__in=('add_page', 'change_page')).values_list(
+        'id', flat=True)
+
+    rule, created = ACLRule.objects.get_or_create(name='pagina propia {}'.format(str(user)),
+                              slug='miembros/{}'.format(
+                                  get_slug(user.username)),
+                              apply_to=ACLRule.TO_EXPLICIT_LIST,
+                              as_namespace=True
+                              )
+    if created:
+        rule.permissions.add(*perms)
+        rule.users.add(user)

--- a/community/templates/header.html
+++ b/community/templates/header.html
@@ -1,5 +1,7 @@
 {% load staticfiles i18n %}
 
+{% load devtags %}
+
 <header id="header" class="navbar navbar-static-top" role="banner">
     <div class="container">
         <div class="row">
@@ -14,7 +16,7 @@
                     <a href="/" class="navbar-brand">PyAr</a>
                     <div class="loginreg">
                       {% if user.is_authenticated %}
-                      Hola {{ user }}. <a href="{% url 'account_logout' %}">{% trans 'Cerrar sesión' %}</a>
+                      Hola <a href="{{ user|wikify:"miembros/" }}">{{ user }}</a>. <a href="{% url 'account_logout' %}">{% trans 'Cerrar sesión' %}</a>
                       {% else %}
                       <a href="{% url 'account_login' %}">{% trans 'Ingresá' %}</a> o <a href="{% url 'account_signup' %}">{% trans 'Registrate' %}</a>
                       {% endif %}

--- a/community/templatetags/devtags.py
+++ b/community/templatetags/devtags.py
@@ -1,5 +1,7 @@
 from django.template import Library
 from lxml import etree
+from django.core.urlresolvers import reverse
+from waliki.settings import get_slug
 
 register = Library()
 
@@ -34,3 +36,9 @@ def html2text(html):
             encoding='utf8', method='text'
         )
     return ''
+
+
+@register.filter
+def wikify(value, prefix=''):
+    slug = get_slug(prefix + str(value))
+    return reverse('waliki_detail', args=[slug])

--- a/pyarweb/settings.py
+++ b/pyarweb/settings.py
@@ -29,11 +29,6 @@ SITE_ID = 1
 TEMPLATE_DIRS = (os.path.join(BASE_DIR, 'templates'),)
 TEMPLATE_DEBUG = True
 
-# Instead of sending out real emails the console backend just writes
-# the emails that would be sent to the standard output.
-# By default, the console backend writes to stdout
-if DEBUG:
-    EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 ALLOWED_HOSTS = []
 
@@ -131,7 +126,7 @@ DATABASES = {
 # Internationalization
 # https://docs.djangoproject.com/en/1.6/topics/i18n/
 
-LANGUAGE_CODE = 'es-AR'
+LANGUAGE_CODE = 'es'
 
 TIME_ZONE = 'America/Argentina/Buenos_Aires'
 
@@ -229,6 +224,12 @@ try:
     from .local_settings import *
 except:
     pass
+
+# Instead of sending out real emails the console backend just writes
+# the emails that would be sent to the standard output.
+# By default, the console backend writes to stdout
+if DEBUG:
+    EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 
 if RAVEN_CONFIG:

--- a/templates/waliki/whatchanged.html
+++ b/templates/waliki/whatchanged.html
@@ -1,0 +1,41 @@
+{% extends "waliki/detail.html" %}
+{% load i18n %}
+{% load devtags %}
+
+{% block header %}
+    {% block title %}<h1>{% trans "What changed" %}</h1>{% endblock title %}
+{% endblock %}
+{% block content %}
+
+
+<table class="table table-striped">
+        <tbody>
+            {% for change in changes %}
+                <tr>
+                  <td class="col-sm-1"><a href="{{ change.page.get_absolute_url }}">{{ change.page.slug }}</td>
+                  <td class="col-sm-1"><a href="{% url 'waliki_version' change.page.slug change.version %}" rel="nofollow">{{ change.version }}</a></td>
+                  {% with change.version|add:"^" as parent %}
+                  <td class="col-sm-1"><a href="{% url 'waliki_diff' change.page.slug parent change.version %}" rel="nofollow">{% trans "diff" %}</a></td>
+                  {% endwith %}
+                  <td class="col-sm-1"><a href="{{ change.author|wikify:"miembros/" }}">{{ change.author }}</a></td>
+                  <td class="col-sm-2" title="{{ change.date }}">{{ change.date }}</td>
+                  <td class="col-sm-3">{{ change.message }}</td>
+
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+
+
+
+      <nav>
+        <ul class="pager">
+          <li class="previous {% if not prev %}disabled{% endif %}"><a href="{% if prev %}{% url 'waliki_whatchanged' prev %}{% else %}#{% endif %}">{% trans "Previous" %}</a></li>
+          <li class="next {% if not next %}disabled{% endif %}"><a href="{% if next %}{% url 'waliki_whatchanged' next %}{% else %}#{% endif %}">{% trans "Next" %}</a></li>
+        </ul>
+      </nav>
+
+
+</div>
+</div>
+{% endblock content %}


### PR DESCRIPTION
Esta es una implementación muy simple de #265 para que cada usuario tenga una pagina de edicion exclusiva en la wiki, de la forma `miembros/username`

Captura la señal cuando se da de alta un nuevo usuario y crea el permiso de edicion correspondiente (inhabilitando a cualquier otro a editar esa pagina). 

Para crear la regla correspondientes a los usuarios preexistentes hay que lanzar la señal programaticamente 

```
$ python manage.py shell
```

y ejecutar este codigo

``` python
from allauth.account import signals
from django.contrib.auth.models import User
for u in User.objects.all():
    signals.user_signed_up.send(sender=User, requests=None, user=u)
```









