### PR TITLE
Order tags by name, add input to search tags

### DIFF
--- a/community/templates/_tags_filtering_form.html
+++ b/community/templates/_tags_filtering_form.html
@@ -6,8 +6,19 @@
     </header>
     <article class="list-group-item">
         <form method="GET" class="col-md-12" id="tags-form">
+            <div class="row">
+                <div class="form-group">
+                    <input id="search-tag" autocomplete="off" class="form-control" name="filtro" placeholder="{% trans 'Buscar etiqueta' %}">
+                </div>
+            </div>
+            <div class="row">
+                <div class="form-group">
+                    <button type="submit" class="btn btn-primary">{% trans 'Filtrar' %}</button>
+                    <button type="button" class="btn btn-default" id="reset-btn">{% trans 'Limpiar' %}</button>
+                </div>
+            </div>
             <div class="row tags-group">
-                {% for tag in tags %}
+                {% for tag in tags|dictsort:"name" %}
                 <select name="tag_{{ tag.slug }}" id="tag_{{ tag.slug }}" class="hidden">
                     <option value="0"></option>
                     <option value="1" {% if tag.slug in included %}selected{% endif %}></option>
@@ -17,12 +28,6 @@
                     {{ tag.name }}
                 </label>
                 {% endfor %}
-            </div>
-            <div class="row">
-                <div class="form-group">
-                    <button type="submit" class="btn btn-primary">{% trans 'Filtrar' %}</button>
-                    <button type="button" class="btn btn-default" id="reset-btn">{% trans 'Limpiar' %}</button>
-                </div>
             </div>
         </form>
         <div class="clearfix"></div>

--- a/static/js/tag_filtering.js
+++ b/static/js/tag_filtering.js
@@ -22,3 +22,9 @@ $('#tags-form #reset-btn').click(function() {
     });
     $('#tags-form .filter_tag').addClass(classNames[0]);
 });
+
+
+$('#search-tag').on('keyup', function(event){
+    $('.filter_tag:not(:contains("' + $(event.target).val() + '"))').css('display', 'none');
+    $('.filter_tag:contains("' + $(event.target).val() + '"), .filter_tag.included').css('display', 'inline-block');
+})


### PR DESCRIPTION
Referido al issue #341

- Ordenar las etiquetas por nombre
- Colocar los botones *Limpiar* y *Filtrar* arriba de las etiquetas
- Agregar un typeahead para buscar entre las etiquetas 

![captura de pantalla 2016-03-24 a las 22 13 51](https://cloud.githubusercontent.com/assets/1164014/14035526/1796e6a6-f20e-11e5-93e1-392f6518050c.png)