### PR TITLE
Filtro por tags: solo parámetros explicitamente seleccionados

### DIFF
--- a/community/templates/_tags_filtering_form.html
+++ b/community/templates/_tags_filtering_form.html
@@ -9,7 +9,7 @@
             <div class="row tags-group">
                 {% for tag in tags %}
                 <select name="tag_{{ tag.slug }}" id="tag_{{ tag.slug }}" class="hidden">
-                    <option value="0"></option>
+                    <option value=""></option>
                     <option value="1" {% if tag.slug in included %}selected{% endif %}></option>
                     <option value="2" {% if tag.slug in excluded %}selected{% endif %}></option>
                 </select>

--- a/static/js/tag_filtering.js
+++ b/static/js/tag_filtering.js
@@ -24,9 +24,8 @@ $('#tags-form #reset-btn').click(function() {
 });
 
 $("#tags-form").submit(function() {
-    $(this).find("select")
-    .prop('disabled', false)
-    .filter(function() {
-        return $(this).val() == 0;
-    }).prop("disabled", true);
+    $('#tags-form select').not(
+            $('#tags-form option:selected').not('[value=""]').parent()
+    ).prop('disabled', true);
+    return true;
 });


### PR DESCRIPTION
un fix rápido para #359 con la idea que propuso @cmdelatorre https://github.com/PyAr/pyarweb/issues/359#issuecomment-249039522

Por ejemplo, esta seleccion 
![image](https://cloud.githubusercontent.com/assets/2355719/18791373/d532b56e-8188-11e6-9f55-c5b049970ae6.png)  serializa a `?tag_python=1&tag_cosa=2` y no se incluye el resto de los tags
