### PR TITLE
Sanitize html inputs on Events and Jobs

### DIFF
--- a/events/forms.py
+++ b/events/forms.py
@@ -1,10 +1,13 @@
 from captcha.fields import CaptchaField
 from crispy_forms.layout import Field
 from django import forms
+from django.conf import settings
 from django_summernote.widgets import SummernoteInplaceWidget
 from django.utils.translation import ugettext_lazy as _
 
 from bootstrap3_datetime.widgets import DateTimePicker
+from sanitizer.forms import SanitizedCharField
+
 from .models import Event, EventParticipation
 from .mixins import CrispyFormMixin, ReadOnlyFieldsMixin
 
@@ -19,7 +22,10 @@ HAS_SPONSORS_HELP_TEXT = _(
 
 class EventForm(CrispyFormMixin):
 
-    description = forms.CharField(widget=SummernoteInplaceWidget())
+    description = SanitizedCharField(
+        allowed_tags=settings.ALLOWED_HTML_TAGS_INPUT,
+        allowed_attributes=settings.ALLOWED_HTML_ATTRIBUTES_INPUT,
+        strip=False, widget=SummernoteInplaceWidget())
 
     start_at = forms.DateTimeField(
         required=True,

--- a/events/tests/factories.py
+++ b/events/tests/factories.py
@@ -1,6 +1,6 @@
 from django.utils.timezone import datetime, timedelta, utc
 from django.contrib.auth import get_user_model
-from factory import SubFactory, Sequence
+from factory import SubFactory, Sequence, Faker, PostGenerationMethodCall
 from factory.django import DjangoModelFactory
 
 from events.models import Event, EventParticipation
@@ -13,16 +13,29 @@ DEFAULT_END_TIME = DEFAULT_START_TIME + timedelta(hours=8)
 
 # This factory could be in any app.
 class UserFactory(DjangoModelFactory):
-    username = Sequence(lambda n: 'user_%i' % n)
+    username = Faker('user_name')
+    password = PostGenerationMethodCall('set_password', 'secret')
 
     class Meta:
         model = User
 
 
 class EventFactory(DjangoModelFactory):
+    name = Faker('sentence', nb_words=4)
+    description = Faker('text')
+    address = Faker('address')
+    place = Faker('sentence', nb_words=2)
     start_at = DEFAULT_START_TIME
     end_at = DEFAULT_END_TIME
     owner = SubFactory(UserFactory)
+
+    class Meta:
+        model = Event
+
+
+class FutureEventFactory(EventFactory):
+    start_at = datetime.today() + timedelta(days=1)
+    end_at = datetime.today() + timedelta(days=2)
 
     class Meta:
         model = Event

--- a/events/tests/factories.py
+++ b/events/tests/factories.py
@@ -1,6 +1,6 @@
 from django.utils.timezone import datetime, timedelta, utc
 from django.contrib.auth import get_user_model
-from factory import SubFactory, Sequence, Faker, PostGenerationMethodCall
+from factory import SubFactory, Faker, PostGenerationMethodCall
 from factory.django import DjangoModelFactory
 
 from events.models import Event, EventParticipation

--- a/events/tests/test_views.py
+++ b/events/tests/test_views.py
@@ -1,0 +1,97 @@
+import bleach
+
+from django.test import TestCase, Client
+from django.core.urlresolvers import reverse
+from django.utils.timezone import now, timedelta
+
+from events.models import Event
+from events.tests.factories import UserFactory, EventFactory, FutureEventFactory
+
+
+class EventsViewTest(TestCase):
+    def setUp(self):
+        self.user = UserFactory()
+        self.client = Client()
+        self.client.login(username=self.user.username, password='secret')
+
+    def test_events_view_list(self):
+        event = EventFactory()
+        response = self.client.get(reverse('events:events_list_all'))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(event, response.context["eventos_pasados"])
+
+    def test_events_feed_view_list(self):
+        event = FutureEventFactory(name="PyDay San Rafael")
+        response = self.client.get(reverse('events:events_feed'))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, event.name)
+
+    def test_events_view_create(self):
+        response = self.client.get(reverse('events:add'))
+        event = {
+            'name': "PyDay San Rafael",
+            'description': "Charlas y talleres",
+            'place': 'UTN Regional, San Rafael',
+            'address': 'Gral. Paz 1432',
+            'url': 'pydaysanrafael.tk',
+            'start_at': (now() + timedelta(days=1)).strftime('%d/%m/%Y 08:00:00'),
+            'end_at': (now() + timedelta(days=1)).strftime('%d/%m/%Y 18:00:00'),
+            'registration_enabled': 1,
+            'has_sponsors': 1
+        }
+        response = self.client.post(reverse('events:add'), event)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(Event.objects.filter(name='PyDay San Rafael').count(), 1)
+
+    def test_events_view_edit(self):
+        event = EventFactory(owner=self.user)
+
+        response = self.client.get(reverse('events:edit', args=(event.pk, )))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["object"], event)
+        event_data = {
+            'name': "PyDay Rio IV",
+            'description': event.description,
+            'place': event.place,
+            'address': event.address,
+            'url': "http://rioiv.python.org.ar",
+            'start_at': (now() + timedelta(days=1)).strftime('%d/%m/%Y 08:00:00'),
+            'end_at': (now() + timedelta(days=1)).strftime('%d/%m/%Y 18:00:00'),
+            'registration_enabled': 1,
+            'has_sponsors': 1
+        }
+        response = self.client.post(reverse('events:edit', args=(event.pk, )), event_data)
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(Event.objects.filter(name=event.name).exists())
+        edit_event = Event.objects.get(pk=event.pk)
+        self.assertEqual(edit_event.name, "PyDay Rio IV")
+        self.assertEqual(edit_event.url, "http://rioiv.python.org.ar")
+
+    def test_html_sanitizer_in_description_field(self):
+        response = self.client.get(reverse('events:add'))
+        event = {
+            'name': "PyDay San Rafael",
+            'description': 'an <script>evil()</script> example',
+            'place': 'UTN Regional, San Rafael',
+            'address': 'Gral. Paz 1432',
+            'url': 'pydaysanrafael.tk',
+            'start_at': (now() + timedelta(days=1)).strftime('%d/%m/%Y 08:00:00'),
+            'end_at': (now() + timedelta(days=1)).strftime('%d/%m/%Y 18:00:00'),
+            'registration_enabled': 1,
+            'has_sponsors': 1
+        }
+        response = self.client.post(reverse('events:add'), event)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(Event.objects.filter(name='PyDay San Rafael').count(), 1)
+        event = Event.objects.filter(name='PyDay San Rafael').get()
+        self.assertEqual(event.description, bleach.clean('an <script>evil()</script> example'))
+
+    def test_events_view_delete(self):
+        event = EventFactory(owner=self.user)
+
+        response = self.client.get(reverse('events:delete', args=(event.pk, )))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["object"], event)
+        response = self.client.post(reverse('events:delete', args=(event.pk, )))
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(Event.objects.filter(name=event.name).exists())

--- a/jobs/forms.py
+++ b/jobs/forms.py
@@ -9,6 +9,7 @@ from crispy_forms.helper import FormHelper
 from django_summernote.widgets import SummernoteInplaceWidget
 from sanitizer.forms import SanitizedCharField
 
+
 class JobForm(forms.ModelForm):
     """A PyAr Jobs form."""
 

--- a/jobs/forms.py
+++ b/jobs/forms.py
@@ -1,17 +1,21 @@
 from random import choice
 from django import forms
+from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 from django.core.urlresolvers import reverse
 from .models import Job, JobInactivated
 from crispy_forms.layout import Submit, Reset, Layout
 from crispy_forms.helper import FormHelper
 from django_summernote.widgets import SummernoteInplaceWidget
-
+from sanitizer.forms import SanitizedCharField
 
 class JobForm(forms.ModelForm):
     """A PyAr Jobs form."""
 
-    description = forms.CharField(widget=SummernoteInplaceWidget())
+    description = SanitizedCharField(
+        allowed_tags=settings.ALLOWED_HTML_TAGS_INPUT,
+        allowed_attributes=settings.ALLOWED_HTML_ATTRIBUTES_INPUT,
+        strip=False, widget=SummernoteInplaceWidget())
 
     def __init__(self, *args, **kwargs):
         super(JobForm, self).__init__(*args, **kwargs)

--- a/jobs/tests/test_views.py
+++ b/jobs/tests/test_views.py
@@ -1,0 +1,85 @@
+import bleach
+
+from django.test import TestCase, Client
+from django.core.urlresolvers import reverse
+
+from jobs.models import Job
+from jobs.tests.factories import JobFactory
+from events.tests.factories import UserFactory
+
+
+class JobsTest(TestCase):
+    def setUp(self):
+        self.user = UserFactory()
+        self.client = Client()
+        self.client.login(username=self.user.username, password='secret')
+
+    def test_jobs_view_list(self):
+        job = JobFactory(owner=self.user)
+        response = self.client.get(reverse('jobs_list_all'))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(job, response.context["job_list"])
+
+    def test_jobs_view_create(self):
+        response = self.client.get(reverse('jobs_add'))
+        job = {
+            'title': 'Python Dev',
+            'location': 'Bahia Blanca',
+            'email': 'info@undominio.com',
+            'tags': 'python,remoto,django',
+            'description': 'Buscamos desarrollador python freelance.'
+        }
+        response = self.client.post(reverse('jobs_add'), job)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(Job.objects.filter(title='Python Dev').count(), 1)
+
+    def test_jobs_view_edit(self):
+        job = JobFactory(
+            owner=self.user, title='Python Dev',
+            description='Buscamos desarrollador python freelance',
+            location='Bahia Blanca', email='info@undominio')
+
+        response = self.client.get(reverse('jobs_update', args=(job.pk, )))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["object"], job)
+        job_data = {
+            'title': 'Python Dev 2',
+            'location': 'Azul',
+            'email': 'info@undominio.com',
+            'tags': 'python,remoto,django',
+            'description': 'Buscamos desarrollador python freelance.'
+        }
+        response = self.client.post(reverse('jobs_update', args=(job.pk, )), job_data)
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(Job.objects.filter(title='Python Dev').exists())
+        edit_job = Job.objects.get(pk=job.pk)
+        self.assertEqual(edit_job.location, "Azul")
+        self.assertEqual(edit_job.title, "Python Dev 2")
+
+    def test_jobs_view_idelete(self):
+        job = JobFactory(
+            owner=self.user, title='Python/Django Dev',
+            description='Buscamos desarrollador python freelance',
+            location='General Pico', email='info@fdq.com')
+
+        response = self.client.get(reverse('jobs_delete', args=(job.pk, )))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["object"], job)
+
+        response = self.client.post(reverse('jobs_delete', args=(job.pk, )))
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(Job.objects.filter(title='Python/Django Dev').exists())
+
+    def test_html_sanitizer_in_description_field(self):
+        response = self.client.get(reverse('jobs_add'))
+        job = {
+            'title': 'Python Dev',
+            'location': 'Cruz del Eje',
+            'email': 'info@undominio.com',
+            'tags': 'python,remoto,django',
+            'description': 'an <script>evil()</script> example'
+        }
+        response = self.client.post(reverse('jobs_add'), job)
+        self.assertEqual(response.status_code, 302)
+        job = Job.objects.get(title='Python Dev')
+        self.assertEqual(job.description, bleach.clean('an <script>evil()</script> example'))

--- a/pyarweb/settings.py
+++ b/pyarweb/settings.py
@@ -89,6 +89,7 @@ INSTALLED_APPS = (
     'waliki.togetherjs',
     'captcha',
     'email_confirm_la',
+    'sanitizer',
 )
 
 
@@ -241,6 +242,13 @@ EMAIL_CONFIRM_LA_TEMPLATE_CONTEXT = {
 #
 CAPTCHA_LENGTH = 6
 
+ALLOWED_HTML_TAGS_INPUT = [
+    'a', 'b', 'br', 'i', 'u', 'p', 'hr',
+    'pre', 'img', 'span', 'table', 'tbody',
+    'thead', 'tr', 'th', 'td', 'blockquote',
+    'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+]
+ALLOWED_HTML_ATTRIBUTES_INPUT = ['href', 'src', 'style', 'width', 'class']
 
 try:
     from .local_settings import *  # NOQA

--- a/pyarweb/settings.py
+++ b/pyarweb/settings.py
@@ -252,7 +252,7 @@ ALLOWED_HTML_ATTRIBUTES_INPUT = ['href', 'src', 'style', 'width', 'class']
 
 try:
     from .local_settings import *  # NOQA
-except ModuleNotFoundError:
+except ImportError:
     pass
 
 # Instead of sending out real emails the console backend just writes

--- a/pyarweb/settings.py
+++ b/pyarweb/settings.py
@@ -252,7 +252,7 @@ ALLOWED_HTML_ATTRIBUTES_INPUT = ['href', 'src', 'style', 'width', 'class']
 
 try:
     from .local_settings import *  # NOQA
-except:
+except ModuleNotFoundError:
     pass
 
 # Instead of sending out real emails the console backend just writes

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,6 @@ django-planet==0.10.1
 django-sendfile==0.3.11
 django-simple-captcha==0.5.3
 django-summernote==0.8.6
-psycopg2==2.7.1
+psycopg2==2.7.4
 waliki==0.7
+django-html-sanitizer==0.1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,3 @@ django-summernote==0.8.6
 psycopg2==2.7.4
 waliki==0.7
 django-html-sanitizer==0.1.5
-factory-boy==2.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ django-email-obfuscator==0.1.5
 django-extensions==1.7.7
 django-model-utils==2.6.1
 django-taggit==0.22.0
-django-taggit-autosuggest==0.3.0
+django-taggit-autosuggest==0.3.3
 django-planet==0.10.1
 django-sendfile==0.3.11
 django-simple-captcha==0.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ django-summernote==0.8.6
 psycopg2==2.7.4
 waliki==0.7
 django-html-sanitizer==0.1.5
+factory-boy==2.10.0

--- a/static/jquery-autosuggest/css/autoSuggest.css
+++ b/static/jquery-autosuggest/css/autoSuggest.css
@@ -96,7 +96,7 @@ ul.as-selections li.as-original {
 }
 
 ul.as-selections li.as-original input {
-    height: 14px !important;
+    height: 28px !important;
 }
 
 ul.as-list {

--- a/templates/jobs/job_form.html
+++ b/templates/jobs/job_form.html
@@ -7,6 +7,9 @@
 {% block extra_head %}
 <script type="text/javascript">
 // Taken from jquery.init.js from django/admin
+/* El plguin que sugiere tags (django-taggit-autosuggest) está pensado para funcionar
+en el admin de django, entonces espera que django.jQuery esté definido.
+*/
 var django = {
     "jQuery": jQuery.noConflict(true)
 };

--- a/templates/jobs/job_form.html
+++ b/templates/jobs/job_form.html
@@ -4,6 +4,17 @@
 
 {% load devtags %}
 
+{% block extra_head %}
+<script type="text/javascript">
+// Taken from jquery.init.js from django/admin
+var django = {
+    "jQuery": jQuery.noConflict(true)
+};
+var jQuery = django.jQuery;
+var $=jQuery;
+</script>
+{% endblock %}
+
 {% block content %}
 <main id="main" class="container" role="main">
     <div class="col-lg-12">


### PR DESCRIPTION
- Se corrige error javascript de autosuggest (por eso no aparecía el editor html)
- Agrego html_sanitizer a los forms de trabajos y de eventos (defino un settings con el listado de tags y atrbituso permitidos)
- Agrego algunos tests de las vistas de trabajos y eventos, y tests del uso de html_sanitizer