### PR TITLE
added normalize_tags function on job utils

### DIFF
--- a/jobs/forms.py
+++ b/jobs/forms.py
@@ -9,6 +9,8 @@ from crispy_forms.helper import FormHelper
 from django_summernote.widgets import SummernoteInplaceWidget
 from sanitizer.forms import SanitizedCharField
 
+from jobs import utils
+
 
 class JobForm(forms.ModelForm):
     """A PyAr Jobs form."""
@@ -78,6 +80,11 @@ class JobForm(forms.ModelForm):
         self.helper.add_input(Submit('job_submit', _('Guardar')))
         self.helper.add_input(Reset('job_reset', _('Limpiar'),
                                     css_class='btn-default'))
+
+    def clean_tags(self):
+        tags = self.cleaned_data.get('tags')
+        self.cleaned_data['tags'] = utils.normalize_tags(tags)
+        return self.cleaned_data['tags']
 
     class Meta:
         model = Job

--- a/jobs/tests/test_utils.py
+++ b/jobs/tests/test_utils.py
@@ -1,0 +1,22 @@
+from django.test import TestCase
+
+from jobs.utils import normalize_tags
+
+
+class UtilTest(TestCase):
+    def test_normalize_tags_with_repeated(self):
+        repeated_tags = ['Django', 'DJANGO', 'djAngo']
+        tags = normalize_tags(repeated_tags)
+        self.assertEqual(len(tags), 1)
+
+    def test_normalize_tags_with_repeated_and_spaces(self):
+        repeated_tags = ['Django', ' DJANGO', 'djAngo ']
+        tags = normalize_tags(repeated_tags)
+        self.assertEqual(len(tags), 1)
+
+    def test_normalize_tags_with_non_ascii(self):
+        repeated_tags = ['DñàÈ', ]
+        tags = list(normalize_tags(repeated_tags))
+        self.assertEqual(len(tags), 1)
+        self.assertTrue(tags[0].islower())
+        self.assertTrue('dnae' == tags[0])

--- a/jobs/tests/test_views.py
+++ b/jobs/tests/test_views.py
@@ -33,6 +33,21 @@ class JobsTest(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(Job.objects.filter(title='Python Dev').count(), 1)
 
+    def test_jobs_view_create_avoiding_repeated_tags(self):
+        response = self.client.get(reverse('jobs_add'))
+        job = {
+            'title': 'Python Dev',
+            'location': 'Bahia Blanca',
+            'email': 'info@undominio.com',
+            'tags': 'python,remoto,DJANGO,django',
+            'description': 'Buscamos desarrollador python freelance.'
+        }
+        response = self.client.post(reverse('jobs_add'), job)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(Job.objects.filter(title='Python Dev').count(), 1)
+        self.assertEqual(Job.objects.all()[0].tags.all().count(), 3)
+
     def test_jobs_view_edit(self):
         job = JobFactory(
             owner=self.user, title='Python Dev',

--- a/jobs/utils.py
+++ b/jobs/utils.py
@@ -1,0 +1,15 @@
+import unicodedata
+
+
+def normalize_tags(tags):
+    """
+        Parse a list of tags and removed duplicated tags and non valid chars
+
+    """
+    results = set()
+    for tag in tags:
+        tag_stripped = tag.strip()
+        value = unicodedata.normalize("NFKD", tag_stripped.lower())
+        value = value.encode('ascii', 'ignore').decode('utf-8')
+        results.add(value)
+    return results

--- a/pyarweb/settings.py
+++ b/pyarweb/settings.py
@@ -264,3 +264,5 @@ if DEBUG:
 
 if RAVEN_CONFIG:
     INSTALLED_APPS += ('raven.contrib.django.raven_compat',)
+
+TAGGIT_CASE_INSENSITIVE = True


### PR DESCRIPTION
@edvm 
Agregamos un archivo utils en jobs con una función normalizadora de tags. Esta funcion se usa en el clean del form:
- convierte a minusculas
- stripea
- convierte a ascii ascentos y ñ
@cmdelatorre no pudimos hacer la magia que charlamos del signal

Además agregamos una setting de django-taggit para evitar carga de repetidos.
Y muchas gracias a @malderete  por la gran ayuda!
