### PR TITLE
Show slugs in the URLs of the events

### DIFF
--- a/community/templates/community/index.html
+++ b/community/templates/community/index.html
@@ -70,19 +70,19 @@
                 <div class="panel-body">
                     {% for article in recent %}
                     <article class="list-group-item">
-                        <time 
-                            class="published" 
-                            datetime="{{ article.created.isoformat }}" 
-                            itemprop="datePublished" 
+                        <time
+                            class="published"
+                            datetime="{{ article.created.isoformat }}"
+                            itemprop="datePublished"
                             title="{{ "Fecha de publicación" }}"
                         >
                             {{ article.created|date:"d/m/Y" }}
-                        </time> 
-                        <small class="text-muted"> 
+                        </time>
+                        <small class="text-muted">
                             - en {{ article.category }}
                         </small>
                         <h4 class="list-group-item-heading">
-                            <a href="{{ article.get_absolute_url }}">{{ article.title }}</a>
+                            <a href="{{ article.get_absolute_url }}#{{ article.title | slugify }}">{{ article.title }}</a>
                         </h4>
                         <p class="list-group-item-text">
                             {{ article.description|html2text|truncatewords:30 }}

--- a/templates/email_confirm_la/email_confirmation_success.html
+++ b/templates/email_confirm_la/email_confirmation_success.html
@@ -9,7 +9,7 @@
         <h2>
             {% trans "Inscripción confirmada" %}
             <span class="section-button-group pull-right">
-                <a href="{% url 'events:detail' email_confirmation.content_object.event.id %}"
+                <a href="{% url 'events:detail' email_confirmation.content_object.event.id %}#{{ email_confirmation.content_object.event.name | slugify }}"
                         class="btn btn-info">
                     {% trans "Volver al evento" %}
                 </a>

--- a/templates/events/event_list.html
+++ b/templates/events/event_list.html
@@ -34,7 +34,7 @@
     {% for event in eventos_proximos %}
       <article class="list-group-item">
         <h4 class="list-group-item-heading">
-          <a href="{% url 'events:detail' event.id %}">
+          <a href="{% url 'events:detail' event.id %}#{{ event.name | slugify }}">
             {{ event.name }}
           </a> |
           <small>
@@ -65,7 +65,7 @@
 
       <article class="list-group-item">
         <h4 class="list-group-item-heading">
-          <a href="{% url 'events:detail' event.id %}">
+          <a href="{% url 'events:detail' event.id %}#{{ event.name | slugify }}">
             {{ event.name }}
           </a> |
           <small>

--- a/templates/events/eventparticipation_confirm_delete.html
+++ b/templates/events/eventparticipation_confirm_delete.html
@@ -19,7 +19,7 @@
                     </h4>
 
 				    <input type="submit" value="Si" class="btn btn-danger">
-				    <a href="{% url 'events:detail' object.event.id %}" class="btn btn-default">No</a>
+				    <a href="{% url 'events:detail' object.event.id %#{{ object.event.name | slugify }}}" class="btn btn-default">No</a>
 				</form>
 	        </div>
 	    </div>

--- a/templates/events/eventparticipation_form.html
+++ b/templates/events/eventparticipation_form.html
@@ -32,8 +32,10 @@
                         {% endif %}
 
                         <span class="section-button-group pull-right">
-                            <a href="{% url 'events:detail' form.initial.event.id %}" class="btn btn-info">
-                                {% trans "Volver al evento" %}
+                            <a
+                                href="{% url 'events:detail' form.initial.event.id %}#{{ form.initial.event.name | slugify }}"
+                                class="btn btn-info">
+                                    {% trans "Volver al evento" %}
                             </a>
                             {% if form.instance.id %}
                                 <a href="{% url 'events:unregister' form.instance.event.id form.instance.id %}" class="btn btn-danger">
@@ -52,7 +54,7 @@
                 <h2>
                     {% trans "Este evento no permite inscripción." %}
                     <span class="section-button-group pull-right">
-                        <a href="{% url 'events:detail' form.initial.event.id %}" class="btn btn-info">
+                        <a href="{% url 'events:detail' form.initial.event.id %}#{{ form.initial.event.name | slugify }}" class="btn btn-info">
                             {% trans "Volver al evento" %}
                         </a>
                     </span>

--- a/templates/events/eventparticipation_list.html
+++ b/templates/events/eventparticipation_list.html
@@ -17,7 +17,7 @@
                             <span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span>
                             {% trans "Bajar CSV" %}
                         </a>
-                        <a href="{% url 'events:detail' event.id %}" class="btn btn-info">{% trans "Volver al evento" %}</a>
+                        <a href="{% url 'events:detail' event.id %}#{{ event.name | slugify }}" class="btn btn-info">{% trans "Volver al evento" %}</a>
                     </span>
                 </h2>
                 <h4>Lista de inscriptos al evento <strong><i>{{ event.name }}</i></strong></h4>

--- a/templates/events/next_events.html
+++ b/templates/events/next_events.html
@@ -1,14 +1,14 @@
 {% for event in events %}
     <article class="list-group-item">
       <h4 class="list-group-item-heading">
-        <a href="{% url 'events:detail' event.id %}">
+        <a href="{% url 'events:detail' event.id %}#{{ event.name | slugify }}">
           {{ event.name }}
         </a>
       </h4>
-      
+
       <p class="list-group-item-text">
-        <span>{{ event.start_at|date:"DATE_FORMAT" }}</span> | 
-        <span>{{ event.start_at|time:"TIME_FORMAT" }}</span> | 
+        <span>{{ event.start_at|date:"DATE_FORMAT" }}</span> |
+        <span>{{ event.start_at|time:"TIME_FORMAT" }}</span> |
         <span>{{ event.place }}</span>
       </p>
     </article>


### PR DESCRIPTION
closes #243 

La solución (simple) que implementamos es la siguiente: no modificamos las URLs, sino que al momento de mostrarlas (o sea en los templates), _appendeamos_ `#un-slug-del-titulo`. Por ejemplo `https://www.python.org.ar/eventos/60/#python-sprint-day-cordoba`

De esta manera, 

- quedan URLs informativas, más amigables para los usuarios
- No hay complicaciones técnicas ya que todo lo que sigue al `#` se puede obviar desde el punto de vista del backend (porque decidimos mantener el ID único de la instancia),
- Permite que la URL cambie si se cambia el título de un evento, al mismo tiempo que las URLs pre-existentes siguen funcionando.

Laburo hecho con @emilioramirez y @tonisgo