### PR TITLE
Issue-441: Add confirmation email templates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5
+FROM python:3.6
 ENV PYTHONUNBUFFERED 1
 ENV PYTHONPATH /code:$PYTHONPATH
 RUN mkdir /code

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.5
 ENV PYTHONUNBUFFERED 1
 ENV PYTHONPATH /code:$PYTHONPATH
 RUN mkdir /code

--- a/templates/account/email_confirm.html
+++ b/templates/account/email_confirm.html
@@ -1,0 +1,36 @@
+{% extends "account/base.html" %}
+
+{% load i18n %}
+{% load account %}
+
+{% block head_title %}{% trans "Confirm E-mail Address" %}{% endblock %}
+
+
+{% block container %}
+<div class="row">
+  <div class="col-md-8 col-md-offset-2">
+    <div class="text-center">
+      <h1>{% trans "Confirm E-mail Address" %}</h1>
+
+      {% if confirmation %}
+
+      {% user_display confirmation.email_address.user as user_display %}
+
+      <p>{% blocktrans with confirmation.email_address.email as email %}Please confirm that <a href="mailto:{{ email }}">{{ email }}</a> is an e-mail address for user {{ user_display }}.{% endblocktrans %}</p>
+
+      <form method="post" action="{% url 'account_confirm_email' confirmation.key %}">
+      {% csrf_token %}
+        <button class="btn btn-primary" type="submit">{% trans 'Confirm' %}</button>
+      </form>
+
+      {% else %}
+
+      {% url 'account_email' as email_url %}
+
+      <p>{% blocktrans %}This e-mail confirmation link expired or is invalid. Please <a href="{{ email_url }}">issue a new e-mail confirmation request</a>.{% endblocktrans %}</p>
+
+      {% endif %}
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/templates/account/verification_sent.html
+++ b/templates/account/verification_sent.html
@@ -1,0 +1,19 @@
+{% extends "account/base.html" %}
+
+{% load i18n %}
+
+{% block head_title %}{% trans "Verify Your E-mail Address" %}{% endblock %}
+
+
+{% block container %}
+<div class="row">
+  <div class="col-md-8 col-md-offset-2">
+    <div class="text-center">
+      <h1>{% trans "Verify Your E-mail Address" %}</h1>
+
+      <p>{% blocktrans %}We have sent an e-mail to you for verification. Follow the link provided to finalize the signup process. Please contact us if you do not receive it within a few minutes.{% endblocktrans %}</p>
+    </div>
+  </div>
+</div>
+{% endblock %}
+


### PR DESCRIPTION
Este PR agrega dos templates relacionados al flujo de confirmación de la dirección de correo electrónico cuando un usuario se registra. Seguí lineamientos similares a los que estaban en las páginas de signup y login.

Captura de _/accounts/confirm-email/_
![Screenshot from 2019-04-03 17-55-52](https://user-images.githubusercontent.com/8465201/55512809-6b4fe200-563a-11e9-9473-0d860c6c7c34.png)

Captura de _/accounts/confirm-email/{token}_
![Screenshot from 2019-04-03 17-57-20](https://user-images.githubusercontent.com/8465201/55512813-6d19a580-563a-11e9-8bc1-6dba6e8475ff.png)
