### PR TITLE
Issue 472 - Corrige filtrado por tags

### DIFF
--- a/community/views.py
+++ b/community/views.py
@@ -102,8 +102,7 @@ class FilterableList(MultipleObjectMixin):
                     self.excluded_tags.append(k[4:])
         return super(FilterableList, self).dispatch(request, *args, **kwargs)
 
-    def get_queryset(self):
-        obj_list = super(FilterableList, self).get_queryset()
+    def filter_queryset_tags(self, obj_list):
         included = self.included_tags
         excluded = self.excluded_tags
         if included:
@@ -111,6 +110,9 @@ class FilterableList(MultipleObjectMixin):
         if excluded:
             obj_list = obj_list.exclude(tags__slug__in=excluded).distinct()
         return obj_list
+
+    def get_queryset(self):
+        return self.filter_queryset_tags(super(FilterableList, self).get_queryset())
 
     def get_context_data(self, **kwargs):
         context = super(FilterableList, self).get_context_data(**kwargs)

--- a/jobs/tests/test_views.py
+++ b/jobs/tests/test_views.py
@@ -29,6 +29,18 @@ class JobsTest(TestCase):
         self.assertIn(sponsored_job2, response.context["sponsored_jobs"])
         self.assertEqual(len(response.context["sponsored_jobs"]), 2)
 
+    def test_jobs_view_list_with_tags(self):
+        job = JobFactory(owner=self.user)
+        job_2 = JobFactory(owner=self.user)
+
+        job.tags.add('tag1')
+        job_2.tags.add('tag2')
+
+        response = self.client.get(reverse('jobs_list_all'), {'tag_tag1': 1})
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(job, response.context["job_list"])
+        self.assertEqual(len(response.context["job_list"]), 1)
+
     def test_jobs_view_list_regular_and_sponsored(self):
         sponsored_company = CompanyFactory(name='Name', owner=self.user, rank=3)
         sponsored_job = JobFactory(owner=self.user, company=sponsored_company)

--- a/jobs/views.py
+++ b/jobs/views.py
@@ -76,8 +76,9 @@ class JobList(ListView, JobActiveMixin, FilterableList):
     COUNT_OF_SPONSORED = 3
 
     def get_queryset(self):
-        return Job.objects.non_sponsored(
+        qs = Job.objects.non_sponsored(
             self.two_month_ago, self.COUNT_OF_SPONSORED)
+        return self.filter_queryset_tags(qs)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
Corrige issue #472 

La clase FilterableList usa el query_set padre y no el que se extendió en JobList. Separé el filtrado del query_set para poder llamarlo aparte.

Agregue un test para probarlo.