### PR TITLE
Linkear al código de conducta de pyar en vez de tener otro propio diferente

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,21 +1,3 @@
 # Código de conducta
 
-Valoramos la participación de cada miembro de la comunidad Python y queremos que todos tengan una experiencia agradable y satisfactoria. En consecuencia, se espera que todos los contribuyentes de este proyecto sean respetuosos.
-
-Para no dejar lugar a dudas, lo que se espera es que todos los contribuyentes de este repositorio cumplan el siguiente Código de Conducta. Los administradores serán responsables de fomentar el cumplimiento de este código.
-
-Los administradores estarán encantado de ayudar a los participantes a que se sientan seguros y libres de acoso, por lo que si surgen problemas cubiertos por este código de conducta, por favor póngase en contacto con ellos escribiendo a coc@ac.python.org.ar. 
-Cualquier queja será confidencial, será tomado en serio, investigada y tratada adecuadamente.
-
-Si un participante se involucra en comportamiento que viola el código de conducta, los administradores pueden tomar cualquier acción que consideren apropiadas, incluyendo advertencia al infractor o la expulsión.
-
-Todos tienen derecho a ser tratados con cortesía, dignidad y respeto y estar libre de cualquier forma de discriminación, victimización, acoso o intimidación; como así también a disfrutar de un ambiente libre de comportamiento no deseado, lenguaje inapropiado e imágenes inadecuadas.
-
-Está terminantemente prohibido el acoso. Entendiendo por éste, la comunicación ofensiva relacionada con el género, la orientación sexual, la discapacidad, la apariencia física, el tamaño corporal, la raza, la religión, las imágenes sexuales en espacios públicos, intimidación deliberada, acecho.
-
-Sea amable con los demás: confiamos en que podrán tratar a los demás de una manera que refleja la opinión generalizada de que la diversidad y la amabilidad son los puntos fuertes de nuestra comunidad que se celebran y fomentan.
-
-Tenga cuidado con las palabras que elija. Recuerde que los chistes de exclusión sexistas, racistas, y otros pueden ser ofensivos para quienes le rodean.
-
-
-Por cualquier problema contactate con un administrador o escribí a coc@ac.python.org.ar
+Este repositorio adhiere a los principios y el Código de Conducta de la Asociación Civil Python Argentina, accesibles online en: https://ac.python.org.ar/#coc. Se espera que todos los contribuyentes de este repositorio lo cumplan, y los mecanismos para reportar problemas son los que ofrece dicha asociación en la misma url. Los administradores serán responsables de fomentar el cumplimiento de este código.


### PR DESCRIPTION
Para evitar tener que actualizar ambos cada vez que haya cambios, y proveer los mismos mecanismos de denuncia, etc.