### PR TITLE
Solve flaky test

### DIFF
--- a/joboffers/tests/test_utils.py
+++ b/joboffers/tests/test_utils.py
@@ -149,7 +149,7 @@ def test_get_visualization_data():
 
     expected_data = [
       (
-        visualization.created_at.date(), visualization.created_at.astimezone().time(),
+        visualization.created_at.astimezone().date(), visualization.created_at.astimezone().time(),
         visualization.joboffer.id, visualization.joboffer.title,
         visualization.event_type, visualization.get_event_type_display()
       )


### PR DESCRIPTION
Por temas de timezone, el test fallaba. Normalize el `created_at` al igual que ya se hace con el time ya que la visualization lo normaliza cuando se busca el objecto de la DB