### PR TITLE
Mejoré el mensaje de error al no encontrar una empresa para indicar cómo crearla.

### DIFF
--- a/templates/companies/company_association_list.html
+++ b/templates/companies/company_association_list.html
@@ -42,9 +42,12 @@
         </div>
       {% elif busqueda  %}
         <div class="col-md-12">
-          <p>{% trans 'No existen empresas para esta busqueda.' %}</p>
+            <p>{% trans 'No existen empresas para esta busqueda. Podés <a href="/empresas/agregar/">crear una empresa acá</a>.' %}</p>
         </div>
       {% endif %}
     </div>
   </section>
+{% endblock %}
+
+{% block right-column %}
 {% endblock %}


### PR DESCRIPTION
Fixes #561.

Notar que NO puse un botón a la derecha como indica el issue. Esto es para evitar la "tentación" o "facilidad" de crear la empresa antes de buscarla.

Entonces el usuario se ve forzado a buscar la empresa, y recién al no encontrarla tiene un link para ir a crearla.

Aproveché también y "pisé" la columna de la derecha, porque sino trae lo que tiene `base_site.html` que es OTRA búsqueda (de páginas) y lista de eventos, que confunde mucho al ya ser esta página algo de búsqueda....