### PR TITLE
Mejoré qué botones se muestran al ver una compañía.

### DIFF
--- a/pycompanies/tests/test_views.py
+++ b/pycompanies/tests/test_views.py
@@ -155,7 +155,7 @@ def test_company_admin_should_have_two_companies_in_context(logged_client):
     LAST_NAME_1 = 'lastname1'
 
     profile_1 = UserCompanyProfileFactory.create(
-      company=company_1, user__first_name=FIRST_NAME_1, user__last_name=LAST_NAME_1
+        company=company_1, user__first_name=FIRST_NAME_1, user__last_name=LAST_NAME_1
     )
     profile_2 = UserCompanyProfileFactory.create(company=company_2)
     profile_3 = UserCompanyProfileFactory.create(company=company_2)
@@ -234,7 +234,7 @@ def test_company_disassociate_one_user_from_company(logged_client, user):
 
 
 @pytest.mark.django_db
-def test_company_detail_doesnt_show_analytics_button_for_normal_user(user, logged_client):
+def test_company_detail_buttons_flags_for_normal_user(user, logged_client):
     """
     Test that the company page doesn't show the analytics button for authenticated users that
     doesn't belong to the current company
@@ -250,11 +250,12 @@ def test_company_detail_doesnt_show_analytics_button_for_normal_user(user, logge
 
     response = client.get(target_url)
 
-    assert response.context_data['can_view_analytics'] is False
+    assert response.context_data['user_company_related'] is False
+    assert response.context_data['user_is_superuser'] is False
 
 
 @pytest.mark.django_db
-def test_company_detail_show_analytics_button_for_admin_user(admin_client):
+def test_company_detail_buttons_flags_for_admin_user(admin_client):
     """
     Test that the company page show the analytics button for an admin user
     """
@@ -265,11 +266,12 @@ def test_company_detail_show_analytics_button_for_admin_user(admin_client):
 
     response = client.get(target_url)
 
-    assert response.context_data['can_view_analytics'] is True
+    assert response.context_data['user_company_related'] is False
+    assert response.context_data['user_is_superuser'] is True
 
 
 @pytest.mark.django_db
-def test_company_detail_show_analytics_button_for_publisher_user(
+def test_company_detail_buttons_flags_for_publisher_user(
     publisher_client, user_company_profile
 ):
     """
@@ -283,7 +285,8 @@ def test_company_detail_show_analytics_button_for_publisher_user(
 
     response = client.get(target_url)
 
-    assert response.context_data['can_view_analytics'] is True
+    assert response.context_data['user_company_related'] is True
+    assert response.context_data['user_is_superuser'] is False
 
 
 @pytest.mark.django_db
@@ -316,17 +319,17 @@ def test_render_company_analytics_ok(
     target_url = reverse('companies:analytics', kwargs={'pk': company.id})
 
     _, views_job_1 = create_analytics_sample_data(
-      test_username=user.username,
-      test_offer_title='Testing Offer 1',
-      test_company=company,
-      max_views_amount=10
+        test_username=user.username,
+        test_offer_title='Testing Offer 1',
+        test_company=company,
+        max_views_amount=10
     )
 
     _, views_job_2 = create_analytics_sample_data(
-      test_username=user.username,
-      test_offer_title='Testing Offer 2',
-      test_company=company,
-      max_views_amount=10
+        test_username=user.username,
+        test_offer_title='Testing Offer 2',
+        test_company=company,
+        max_views_amount=10
     )
 
     response = client.get(target_url)

--- a/pycompanies/views.py
+++ b/pycompanies/views.py
@@ -32,10 +32,9 @@ class CompanyDetailView(DetailView):
         user = self.request.user
         company = self.object
 
-        if UserCompanyProfile.objects.for_user(user=user, company=company) or user.is_superuser:
-            context['can_view_analytics'] = True
-        else:
-            context['can_view_analytics'] = False
+        context['user_company_related'] = bool(
+            UserCompanyProfile.objects.for_user(user=user, company=company))
+        context['user_is_superuser'] = user.is_superuser
 
         return context
 
@@ -117,7 +116,7 @@ class CompanyAdminView(LoginRequiredMixin, TemplateView):
             context['user_company_id'] = user_company.id
             context['own_company'] = user_company.company
             context['company_users'] = UserCompanyProfile.objects.filter(
-              company=context['own_company']
+                company=context['own_company']
             )
 
         return context
@@ -167,7 +166,7 @@ class CompanyAssociationListView(LoginRequiredMixin, ListView):
 
         for user_profiles in company_user_profiles:
             owner_names.append(
-              [get_user_display_name(user_profile.user) for user_profile in user_profiles]
+                [get_user_display_name(user_profile.user) for user_profile in user_profiles]
             )
 
         context['companies_and_owners'] = list(zip(companies, owner_names))

--- a/templates/companies/company_association_list.html
+++ b/templates/companies/company_association_list.html
@@ -42,9 +42,12 @@
         </div>
       {% elif busqueda  %}
         <div class="col-md-12">
-          <p>{% trans 'No existen empresas para esta busqueda.' %}</p>
+            <p>{% trans 'No existen empresas para esta busqueda. Podés <a href="/empresas/agregar/">crear una empresa acá</a>.' %}</p>
         </div>
       {% endif %}
     </div>
   </section>
+{% endblock %}
+
+{% block right-column %}
 {% endblock %}

--- a/templates/companies/company_detail.html
+++ b/templates/companies/company_detail.html
@@ -13,12 +13,12 @@
         <h2>
           {{ object.name }}
           <span class="pull-right">
-            {% if object.owner == user %}
-            <a href="{% url 'companies:edit' object.id %}" class="btn btn-info">{% trans 'Editar' %}</a>
-            <a href="{% url 'companies:delete' object.id %}" class="btn btn-danger">{% trans 'Borrar' %}</a>
+            {% if user_company_related or user_is_superuser %}
+              <a href="{% url 'companies:analytics' object.id %}" class="btn btn-dark-green">{% trans 'Ver analítica' %}</a>
+              <a href="{% url 'companies:edit' object.id %}" class="btn btn-info">{% trans 'Editar datos' %}</a>
             {% endif %}
-            {% if can_view_analytics %}
-              <a href="{% url 'companies:analytics' object.id %}" class="btn btn-dark-green">{% trans 'Analítica' %}</a>
+            {% if user_company_related %}
+              <a href="{% url 'companies:disassociate' object.id %}" class="btn btn-danger">{% trans 'Desvincularme' %}</a>
             {% endif %}
           </span>
         </h2>


### PR DESCRIPTION
Los botones faltantes estaban intentando ser mostrados, pero se estaba usando "owner" que desapareció en el nuevo modelo.

Entonces ahora estoy usando dos flags, uno que indica si el usuario está relacionado con la compañía (para mostrar los tres botones) y otro para ver si el usuario es admin (para mostrar el de ver analítica y editar los datos, no tiene sentido desvincularse ahí).
