### PR TITLE
Moved from ugettext(_lazy) to gettext(_lazy).

### DIFF
--- a/events/forms.py
+++ b/events/forms.py
@@ -3,7 +3,7 @@ from crispy_forms.layout import Field
 from django import forms
 from django.conf import settings
 from django_summernote.widgets import SummernoteInplaceWidget
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from sanitizer.forms import SanitizedCharField
 
@@ -113,7 +113,7 @@ class AnonymousEventParticipationForm(CrispyFormMixin):
         )
         help_texts = {
             'interest': _('¿Qué temas de Python te interesaría ver en una charla?'),
-            'gender':  _('Queremos reducir la brecha de género. Este dato nos ayuda.'),
+            'gender': _('Queremos reducir la brecha de género. Este dato nos ayuda.'),
             'cv': 'Dejanos un link a tu CV, perfil de LinkedIn o algo similar'
         }
 

--- a/events/mixins.py
+++ b/events/mixins.py
@@ -5,7 +5,7 @@ from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Submit, Reset, Layout, Div
 from django import forms
 from django.http import HttpResponse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.urls import reverse_lazy
 
 from .models import Event, EventParticipation

--- a/events/models.py
+++ b/events/models.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.urls import reverse
 
 from autoslug import AutoSlugField

--- a/events/views.py
+++ b/events/views.py
@@ -4,12 +4,10 @@ from django.contrib.messages.views import SuccessMessageMixin
 from django.contrib.syndication.views import Feed
 from django.http import Http404, HttpResponseRedirect
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.urls import reverse_lazy
 from django.views.generic import ListView, DetailView
-from django.views.generic.edit import (CreateView,
-                                       UpdateView,
-                                       DeleteView)
+from django.views.generic.edit import CreateView, UpdateView, DeleteView
 
 from .forms import EventForm, AnonymousEventParticipationForm, AuthenticatedEventParticipationForm
 from .models import Event, EventParticipation

--- a/joboffers/forms.py
+++ b/joboffers/forms.py
@@ -2,7 +2,7 @@ from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from .models import JobOffer, JobOfferComment, Remoteness
 from crispy_forms.layout import Submit, Reset, Layout
 from crispy_forms.helper import FormHelper

--- a/jobs/forms.py
+++ b/jobs/forms.py
@@ -1,7 +1,7 @@
 from random import choice
 from django import forms
 from django.conf import settings
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.urls import reverse
 from .models import Job, JobInactivated
 from crispy_forms.layout import Submit, Reset, Layout

--- a/jobs/models.py
+++ b/jobs/models.py
@@ -2,7 +2,7 @@ from autoslug import AutoSlugField
 from django.conf import settings
 from django.db import models
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from pycompanies.models import Company
 from taggit_autosuggest.managers import TaggableManager
 from model_utils.models import TimeStampedModel

--- a/news/forms.py
+++ b/news/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django_summernote.widgets import SummernoteInplaceWidget
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Submit, Reset
 from .models import NewsArticle

--- a/news/models.py
+++ b/news/models.py
@@ -1,7 +1,7 @@
 from django.db import models
 from django.conf import settings
 from django.urls import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from taggit_autosuggest.managers import TaggableManager
 from model_utils.models import TimeStampedModel
 

--- a/news/views.py
+++ b/news/views.py
@@ -1,7 +1,7 @@
 from django.urls import reverse_lazy
 from django.views.generic.edit import UpdateView, CreateView, DeleteView
 from django.views.generic import ListView
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from community.views import OwnedObject, FilterableList
 from .models import NewsArticle
 from .forms import NewsArticleForm

--- a/pycompanies/forms.py
+++ b/pycompanies/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django_summernote.widgets import SummernoteInplaceWidget
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Div, ButtonHolder, Layout, Submit

--- a/pycompanies/models.py
+++ b/pycompanies/models.py
@@ -3,7 +3,7 @@ from django.db import models
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from model_utils.models import TimeStampedModel
 

--- a/pycompanies/views.py
+++ b/pycompanies/views.py
@@ -6,7 +6,7 @@ from django.core.exceptions import PermissionDenied
 from django.db.models import Count
 from django.shortcuts import redirect, render
 from django.urls import reverse_lazy
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import ListView, DetailView, TemplateView
 from django.views.generic.base import View
 from django.views.generic.edit import UpdateView, CreateView, DeleteView
@@ -232,10 +232,10 @@ class CompanyAnalyticsView(DetailView):
 
     def get_context_data(self, company):
         grouped_views_qs = JobOfferAccessLog.objects \
-                                        .values('created_at__date', 'event_type') \
-                                        .annotate(day_views=Count('id')) \
-                                        .filter(joboffer__company=company) \
-                                        .order_by('created_at__date')
+            .values('created_at__date', 'event_type') \
+            .annotate(day_views=Count('id')) \
+            .filter(joboffer__company=company) \
+            .order_by('created_at__date')
 
         graphs = []
 


### PR DESCRIPTION
This is to avoid zillion messages like this when running tests:

  /home/runner/work/pyarweb/pyarweb/events/models.py:50: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
