### PR TITLE
Only show those tags that correspond with filtered posts.

### DIFF
--- a/community/templates/_tags_filtering_form.html
+++ b/community/templates/_tags_filtering_form.html
@@ -13,8 +13,8 @@
                 </div>
                 <div class="ma-5" style="margin-top:15px;">
                   <label>
-                    <input name="active" type="hidden" value="{{ active|yesno:'false,true' }}">
-                    <input id="show-active" type="checkbox" {% if not active %}checked{% endif %} />
+                    <input name="active" type="hidden" value="{{ active|yesno:'true,false' }}">
+                    <input id="show-active" type="checkbox" {% if active %}checked{% endif %} />
                     {% trans 'Mostrar solo ofertas activas' %}
                   </label>
                 </div>
@@ -25,7 +25,7 @@
         </header>
         <article class="list-group-item" style="padding:30px;">
             <div class="row">
-                    {% for tag in tags %}
+                    {% for tag in usefultags %}
                     <select name="tag_{{ tag.slug }}" id="tag_{{ tag.slug }}" class="hidden">
                         <option value=""></option>
                         <option value="1" {% if tag.slug in included %}selected{% endif %}></option>

--- a/joboffers/tests/test_views.py
+++ b/joboffers/tests/test_views.py
@@ -902,6 +902,34 @@ def test_joboffer_list_view_render_the_joboffer_that_contains_the_given_tag(clie
 
 
 @pytest.mark.django_db
+def test_joboffer_list_view_taglist_all_offers(publisher_client):
+    """Verify which tags are shown on a mix of active/expired offers when showing all of them."""
+    client = publisher_client
+    JobOfferFactory.create(
+        state=OfferState.ACTIVE, title="First Joboffer", tags=["tag1", "tag2"])
+    JobOfferFactory.create(
+        state=OfferState.EXPIRED, title="Second Joboffer", tags=["tag2", "tag3"])
+
+    response = client.get(reverse(LIST_URL), {'active': 'false'})
+
+    assert sorted(t.slug for t in response.context_data['usefultags']) == ["tag1", "tag2", "tag3"]
+
+
+@pytest.mark.django_db
+def test_joboffer_list_view_taglist_only_active_offers(publisher_client):
+    """Verify which tags are shown on a mix of active/expired offers when showing active only."""
+    client = publisher_client
+    JobOfferFactory.create(
+        state=OfferState.ACTIVE, title="First Joboffer", tags=["tag1", "tag2"])
+    JobOfferFactory.create(
+        state=OfferState.EXPIRED, title="Second Joboffer", tags=["tag2", "tag3"])
+
+    response = client.get(reverse(LIST_URL), {'active': 'true'})
+
+    assert sorted(t.slug for t in response.context_data['usefultags']) == ["tag1", "tag2"]
+
+
+@pytest.mark.django_db
 def test_joboffer_list_view_count(client, joboffers_list):
     """
     Test that accessing the joboffer's list page only gives one view

--- a/pyarweb/settings/development/__init__.py
+++ b/pyarweb/settings/development/__init__.py
@@ -17,3 +17,5 @@ SOCIAL_NETWORKS_PUBLISHERS = []  # Empty by default to avoid sending on local te
 
 # BASE_URL to use in any notification that might require them
 BASE_URL = os.environ.get('BASE_URL', 'http://localhost:8000')
+
+DISCOURSE_HOST = "testdiscourse.com"


### PR DESCRIPTION
For this I stopped using `tags` (populated by the library) and started to use `usefultags`, populated in the view considering only those active offers (if the "active" checkbox is selected), or re-using `tags` if the user actually wants to see all the offers.

While doing this I noticed that the "active" boolness was inverted everywhere, fixed that.

Also included `DISCOURSE_HOST` in the development settings (a test was failing).
