### PR TITLE
Better moderation reminders.

### DIFF
--- a/joboffers/constants.py
+++ b/joboffers/constants.py
@@ -127,7 +127,7 @@ Resumen de Visitas
 
 OFFER_EXPIRATION_DAYS = 180
 
-PENDING_MODERATION_OFFER_DAYS = 2
+PENDING_MODERATION_OFFER_DAYS = 0
 
 TELEGRAM_MODERATION_MESSAGE = _('La oferta {offer_url} necesita ser moderada.')
 TELEGRAM_APPROVED_MESSAGE = _('La oferta {offer_url} fue aprobada por {username}.')

--- a/joboffers/management/commands/notify_pending_moderation_offers.py
+++ b/joboffers/management/commands/notify_pending_moderation_offers.py
@@ -15,13 +15,13 @@ def notify_pending_moderation_offers():
     """
     expiration_date = timezone.now() - timedelta(days=PENDING_MODERATION_OFFER_DAYS)
     joboffers = JobOffer.objects.filter(
-      state=OfferState.MODERATION, modified_at__lte=expiration_date
+        state=OfferState.MODERATION, modified_at__lte=expiration_date
     )
 
     for joboffer in joboffers:
         message = TELEGRAM_PENDING_MODERATION_MESSAGE.format(
-          offer_url=joboffer.get_absolute_url(),
-          moderation_reminder_days=PENDING_MODERATION_OFFER_DAYS
+            offer_url=joboffer.get_full_url(),
+            moderation_reminder_days=PENDING_MODERATION_OFFER_DAYS
         )
 
         send_notification_to_moderators(message)
@@ -38,9 +38,8 @@ class Command(BaseCommand):
         offers_notifed = notify_pending_moderation_offers()
 
         self.stdout.write(
-          self.style.SUCCESS(
-            _('Se enviaron {offers_notified} recordatorios de moderación.').format(
-              offers_notified=offers_notifed
+            self.style.SUCCESS(
+                _('Se enviaron {offers_notified} recordatorios de moderación.').format(
+                    offers_notified=offers_notifed)
             )
-          )
         )

--- a/joboffers/tests/test_notify-pending_moderation_offers.py
+++ b/joboffers/tests/test_notify-pending_moderation_offers.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 from joboffers.constants import PENDING_MODERATION_OFFER_DAYS, TELEGRAM_PENDING_MODERATION_MESSAGE
 from joboffers.models import JobOffer, OfferState
 from joboffers.management.commands.notify_pending_moderation_offers import (
-  notify_pending_moderation_offers
+    notify_pending_moderation_offers
 )
 from .factories import JobOfferFactory
 from .fixtures import create_telegram_dummy # noqa
@@ -15,9 +15,7 @@ from .fixtures import create_telegram_dummy # noqa
 
 @pytest.mark.django_db
 def test_remind_offers_in_moderation(telegram_dummy):
-    """
-    Test expiration of old joboffers command
-    """
+    """Expiration of old joboffers command."""
     today = timezone.now()
     two_hundred_days_ago = today - timedelta(days=200)
     JobOfferFactory.create()
@@ -35,6 +33,6 @@ def test_remind_offers_in_moderation(telegram_dummy):
     assert offers_notified == 1
     assert len(telegram_history) == 1
     assert sent_message.endswith(TELEGRAM_PENDING_MODERATION_MESSAGE.format(
-      offer_url=offer2.get_absolute_url(),
-      moderation_reminder_days=PENDING_MODERATION_OFFER_DAYS
+        offer_url=offer2.get_full_url(),
+        moderation_reminder_days=PENDING_MODERATION_OFFER_DAYS
     ))

--- a/joboffers/tests/test_notify-pending_moderation_offers.py
+++ b/joboffers/tests/test_notify-pending_moderation_offers.py
@@ -1,10 +1,11 @@
 import pytest
 
 from datetime import timedelta
+from unittest.mock import patch
 
 from django.utils import timezone
 
-from joboffers.constants import PENDING_MODERATION_OFFER_DAYS, TELEGRAM_PENDING_MODERATION_MESSAGE
+from joboffers.constants import TELEGRAM_PENDING_MODERATION_MESSAGE
 from joboffers.models import JobOffer, OfferState
 from joboffers.management.commands.notify_pending_moderation_offers import (
     notify_pending_moderation_offers
@@ -14,6 +15,9 @@ from .fixtures import create_telegram_dummy # noqa
 
 
 @pytest.mark.django_db
+@patch(
+    "joboffers.management.commands.notify_pending_moderation_offers.PENDING_MODERATION_OFFER_DAYS",
+    2)
 def test_remind_offers_in_moderation(telegram_dummy):
     """Expiration of old joboffers command."""
     today = timezone.now()
@@ -34,5 +38,5 @@ def test_remind_offers_in_moderation(telegram_dummy):
     assert len(telegram_history) == 1
     assert sent_message.endswith(TELEGRAM_PENDING_MODERATION_MESSAGE.format(
         offer_url=offer2.get_full_url(),
-        moderation_reminder_days=PENDING_MODERATION_OFFER_DAYS
+        moderation_reminder_days=2
     ))


### PR DESCRIPTION
Two changes:

- send the **full** URL, not just the absolute path, so the person reading the message just can click on it and go to the offer

- set the "pending days" to 0; this way all not-moderated offers will be reminded when the script runs in the early morning every day (it makes no sense to wait several days to remind about moderation! moderation should happen ASAP, if an offer is still not moderated at the next morning, it was forgotten)