### PR TITLE
Add help text and fix URL validation to prepend https:// if missing

### DIFF
--- a/pycompanies/forms.py
+++ b/pycompanies/forms.py
@@ -1,17 +1,20 @@
 from django import forms
 from django_summernote.widgets import SummernoteInplaceWidget
 from django.utils.translation import gettext_lazy as _
+from urllib.parse import urlparse
 
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Div, ButtonHolder, Layout, Submit
 
 from .models import Company, UserCompanyProfile
 
-
 class CompanyForm(forms.ModelForm):
     """A PyAr companies form."""
 
     description = forms.CharField(widget=SummernoteInplaceWidget())
+    link = forms.CharField(
+        help_text=_('Por favor, ingrese una URL válida con esquema (por ejemplo, https://).')
+    )
 
     def __init__(self, *args, **kwargs):
         super(CompanyForm, self).__init__(*args, **kwargs)
@@ -28,10 +31,15 @@ class CompanyForm(forms.ModelForm):
             )
         )
 
+    def clean_link(self):
+        link = self.cleaned_data.get('link')
+        if link and not urlparse(link).scheme:
+            link = f'https://{link}'
+        return link
+
     class Meta:
         fields = ['name', 'photo', 'link', 'description']
         model = Company
-
 
 class UserCompanyForm(forms.ModelForm):
     """A PyAr user companies form."""


### PR DESCRIPTION
## Cambios propuestos:
-  Added help text to the URL input form to guide users.
-  Fixed validation to automatically prepend https:// to URLs if missing

## Temas tratados:
- Closes #562 

## Pruebas realizadas:
- Built and ran the application inside a Docker container without errors.
- Tested the URL input form with valid and invalid URLs (with and without https://).
- Verified the expected behavior in the Dockerized environment.

## Cómo probar los cambios:
1. Navigate to the form with the URL input field.
2. Enter a URL without https:// (e.g., www.github.com) and save.
3. Verify that https:// is automatically added to the URL and saved correctly

Gracias por contribuir con el proyecto.

Estamos pendiente de revisar los cambios propuestos.
