### PR TITLE
fix docker compose image name to pyar/pyarweb

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
         - POSTGRES_PASSWORD=secret
 
   web:
-      image: pyarweb
+      image: pyar/pyarweb
       command: python3 manage.py runserver 0.0.0.0:8000
       volumes:
         - .:/code


### PR DESCRIPTION
<!-- En primer lugar, GRACIAS por su contribución. -->

## Cambios propuestos:

- cambiar el archivo docker compose para que baje correctamente la imagen.

## Temas tratados:
<!-- Si su arreglo tiene un problema relacionado, enlácelo a continuación -->
1. Clone el proyecto. 
2. Siga las instrucciones en https://github.com/PyAr/pyarweb/wiki/Instalacion-con-Docker
3. No funciona dando como error 
`pull access denied for pyarweb, repository does not exist or may require 'docker login': denied: requested access to the resource is denied`

## Pruebas realizadas:
<!-- ¿Se construye sin errores? ¿Qué has probado? ¿En qué sistema operativo lo has probado? Describe cualquier otra prueba realizada -->

- Funciona permitiendo construir la imagen
-


## Cómo probar los cambios:
<!-- Describir en un orden detallado paso a paso cómo probar los cambios -->

1. Clone el proyecto. 
2. Siga las instrucciones en https://github.com/PyAr/pyarweb/wiki/Instalacion-con-Docker
3. Ahora funciona sin inconvenientes.


Gracias por contribuir con el proyecto.

Estamos pendiente de revisar los cambios propuestos.
